### PR TITLE
Added Pthread to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build/ci
 
 build/ci: src/main.cpp src/ci.cpp | build
-	g++ -std=c++17 src/main.cpp src/ci.cpp -o build/ci
+	g++ -std=c++17 src/main.cpp src/ci.cpp -o build/ci -pthread
 
 test: build/tests
 	./build/tests


### PR DESCRIPTION
Some systems need pthread specified to work when compiling main program. This fixes that. This closes #18.