### PR TITLE
Added HTML listings for CI executions (Issue #8)

### DIFF
--- a/include/ci.hpp
+++ b/include/ci.hpp
@@ -20,6 +20,7 @@ void testingSequence(std::string ref, std::string cloneUrl, std::string commitSH
 int cloneFromGit(std::string cloneUrl, std::string commitSHA, std::string branch);
 int compile_Makefile(std::string repoPath);
 bool connectDB();
+bool createTables(); 
 bool insertToDB(std::string commitSHA, std::string buildLog);
 
 #endif

--- a/include/ci.hpp
+++ b/include/ci.hpp
@@ -11,6 +11,7 @@
 using json = nlohmann::json;
 
 const int port = 8012;
+extern sqlite3 *db;
 
 void incomingWebhook(const httplib::Request &req, httplib::Response &res);
 void listCommits(const httplib::Request &req, httplib::Response &res);

--- a/include/ci.hpp
+++ b/include/ci.hpp
@@ -13,6 +13,8 @@ using json = nlohmann::json;
 const int port = 8012;
 
 void incomingWebhook(const httplib::Request &req, httplib::Response &res);
+void listCommits(const httplib::Request &req, httplib::Response &res);
+void sendCommitInfo(const httplib::Request &req, httplib::Response &res);
 void testingSequence(std::string ref, std::string cloneUrl, std::string commitSHA, std::string branch);
 int cloneFromGit(std::string cloneUrl, std::string commitSHA, std::string branch);
 int compile_Makefile(std::string repoPath);

--- a/include/ci.hpp
+++ b/include/ci.hpp
@@ -14,7 +14,7 @@ const int port = 8012;
 
 void incomingWebhook(const httplib::Request &req, httplib::Response &res);
 void listCommits(const httplib::Request &req, httplib::Response &res);
-void sendCommitInfo(const httplib::Request &req, httplib::Response &res);
+void sendCommitInfo(std::string publicKey, httplib::Response &res);
 void testingSequence(std::string ref, std::string cloneUrl, std::string commitSHA, std::string branch);
 int cloneFromGit(std::string cloneUrl, std::string commitSHA, std::string branch);
 int compile_Makefile(std::string repoPath);

--- a/src/ci.cpp
+++ b/src/ci.cpp
@@ -231,6 +231,15 @@ bool insertToDB(std::string commitSHA, std::string buildLog){
     
 }
 
+/** listCommits
+ *  Function to handle HTTP get messages to grab a list of all builds done by the CI
+ *  server in the past. req does not matter as function is only called when going to
+ *  a specific / of the url. Begins by grabbing all the ids and commit numbers from
+ *  the database, adds them to the HTML as links.
+ * 
+ *  @param req required argument for httplib callback function
+ *  @param res response with HTML to the caller.
+ */
 void listCommits(const httplib::Request &req, httplib::Response &res) {
     try
     {
@@ -277,6 +286,14 @@ void listCommits(const httplib::Request &req, httplib::Response &res) {
     }
 }
 
+/** listCommits
+ *  Function to get data from the database and send it back as HTML for
+ *  a specific CI execution. First grabs neccessary columns from publicKey row
+ *  then sets these ordered in a HTML document and sends back through res.
+ * 
+ *  @param publicKey which publicKey row to grab from. 
+ *  @param res response with HTML to the caller.
+ */
 void sendCommitInfo(std::string publicKey, httplib::Response &res) {
     try
     {

--- a/src/ci.cpp
+++ b/src/ci.cpp
@@ -299,16 +299,16 @@ void sendCommitInfo(std::string publicKey, httplib::Response &res) {
 
         sqlite3_bind_text(stmt, 1, publicKey.c_str(), -1, SQLITE_STATIC);
 
-        sqlite3_step(stmt);
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_ROW) {
+            res.status = 404;
+            res.set_content("sql err", "text/plain");
+            return;
+        }
+
         std::string commit = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
         std::string timestamp = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
         std::string buildLog = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
-
-        if (commit == NULL || timestamp == NULL || buildLog == NULL) {
-            res.status = 404;
-            res.set_content("SQL Row not found!", "text/plain");
-            return;
-        }
 
         std::string html;
 

--- a/src/ci.cpp
+++ b/src/ci.cpp
@@ -156,7 +156,7 @@ bool connectDB(){
 
 bool createTables(){
     const char* query = R"(
-        CREATE TABLE IF NOT EXISTS ci_builds (
+        CREATE TABLE IF NOT EXISTS ci_table (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             commit_id VARCHAR(40) NOT NULL,
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/src/ci.cpp
+++ b/src/ci.cpp
@@ -230,3 +230,52 @@ bool insertToDB(std::string commitSHA, std::string buildLog){
     return true;
     
 }
+
+void listCommits(const httplib::Request &req, httplib::Response &res) {
+    try
+    {
+        // get commits into array or vector
+
+        std::vector<std::string> commits;
+
+        std::string html;
+
+        for (std::string commit : commits) {
+            html += "<a href='/commit/" + commit + "'>" + commit + "<br>";
+        }
+
+        res.status = 200;
+        res.set_content(html, "text/html");
+    }
+    catch(std::exception &e)
+    {
+        res.status = 400;
+        res.set_content("err", "text/plain");
+    }
+}
+
+void sendCommitInfo(const httplib::Request &req, httplib::Response &res) {
+    try
+    {
+        std::string commit = req.path_params.at("id");
+
+        // Get columns from Database
+
+        std::vector<std::string> columns;
+
+        std::string html;
+
+        html += "Test ID: " + columns[0];
+        html += "<br>Commit SHA: " + columns[1];
+        html += "<br>Timestamp: " + columns[2];
+        html += "<br>Log:<br>" + columns[4];
+
+        res.status = 200;
+        res.set_content(html, "text/html");
+    }
+    catch(std::exception &e)
+    {
+        res.status = 400;
+        res.set_content("err", "text/plain");
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,10 @@ int main(int argc, char** argv) {
 
   server.Post("/ci_webhook", incomingWebhook);
   server.Get("/list", listCommits);
-  server.Get("/commit/:id", sendCommitInfo);
+  server.Get("/id/:pk", [](const httplib::Request &req, httplib::Response &res) {
+    std::string publicKey = req.path_params.at("pk");
+    sendCommitInfo(publicKey, res);
+  });
 
   std::cout << "Server starting on port " << port << std::endl;
   

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,15 @@
 #include "../include/ci.hpp"
-
+/** main
+ *  Main function to run the CI server. Uses httplib with developed callbacks
+ *  to get data from a webhook to process the CI execution, but also to run
+ *  an extra listing service which shows links to all previous runs, links 
+ *  which lets you see extra information about each commit. 
+ * 
+ *  Server runs on port 8012
+ * 
+ *  @param argc unused parameter
+ *  @param argv unused parameter
+ */
 int main(int argc, char** argv) {
   httplib::Server server;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@ int main(int argc, char** argv) {
   httplib::Server server;
 
   server.Post("/ci_webhook", incomingWebhook);
+  server.Get("/list", listCommits);
+  server.Get("/commit/:id", sendCommitInfo);
 
   std::cout << "Server starting on port " << port << std::endl;
   

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,9 @@
  *  @param argv unused parameter
  */
 int main(int argc, char** argv) {
+
+  connectDB();
+
   httplib::Server server;
 
   server.Post("/ci_webhook", incomingWebhook);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,8 @@
  */
 int main(int argc, char** argv) {
 
-  connectDB();
+  if(!connectDB()) return 1;
+  if(!createTables()) return 1;
 
   httplib::Server server;
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -174,3 +174,46 @@ TEST_CASE("Tests connecting", "[connectDB]") {
 TEST_CASE("Tests writing to database on testTable ci_tests", "[insertToDB]") {
     REQUIRE(insertToDB("somehash", "somebuildlog") == true);
 }
+
+TEST_CASE("Make List HTML", "[listCommits]") {
+    httplib::Request req;
+    httplib::Response res;
+
+    listCommits(req, res);
+
+    REQUIRE(res.status == 200);
+}
+
+TEST_CASE("Get Info from Database", "[sendCommitInfo]") {
+    connectDB();
+
+    httplib::Response res;
+
+    sendCommitInfo("1", res);
+
+    REQUIRE(res.status == 200);
+    std::cout << res.body;
+}
+
+TEST_CASE("Get non existent Info from Database", "[sendCommitInfo]") {
+    connectDB();
+
+    httplib::Response res;
+
+    sendCommitInfo("-1", res);
+
+    REQUIRE(res.status == 404);
+    std::cout << res.body;
+}
+
+TEST_CASE("Incorrect Public Key", "[sendCommitInfo]") {
+    connectDB();
+
+    httplib::Response res;
+
+    sendCommitInfo("public key :)", res);
+
+    REQUIRE(res.status == 404);
+    std::cout << res.body;
+}
+

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -192,7 +192,6 @@ TEST_CASE("Get Info from Database", "[sendCommitInfo]") {
     sendCommitInfo("1", res);
 
     REQUIRE(res.status == 200);
-    std::cout << res.body;
 }
 
 TEST_CASE("Get non existent Info from Database", "[sendCommitInfo]") {
@@ -203,7 +202,6 @@ TEST_CASE("Get non existent Info from Database", "[sendCommitInfo]") {
     sendCommitInfo("-1", res);
 
     REQUIRE(res.status == 404);
-    std::cout << res.body;
 }
 
 TEST_CASE("Incorrect Public Key", "[sendCommitInfo]") {
@@ -214,6 +212,5 @@ TEST_CASE("Incorrect Public Key", "[sendCommitInfo]") {
     sendCommitInfo("public key :)", res);
 
     REQUIRE(res.status == 404);
-    std::cout << res.body;
 }
 


### PR DESCRIPTION
Added a /list site to list all previous build logs, as well as a /id/xxxxx page where you can get extended info about each CI execution. This closes #8.